### PR TITLE
style: Make pre block text readable

### DIFF
--- a/themes/hugoplate/assets/scss/components.scss
+++ b/themes/hugoplate/assets/scss/components.scss
@@ -58,7 +58,7 @@ main {
   @apply prose-hr:border-border prose-hr:dark:border-darkmode-border;
   @apply prose-p:text-base prose-p:text-text prose-p:dark:text-darkmode-text;
   @apply prose-blockquote:rounded-lg prose-blockquote:border prose-blockquote:border-l-[10px] prose-blockquote:border-primary prose-blockquote:bg-theme-light prose-blockquote:px-8 prose-blockquote:py-10 prose-blockquote:font-secondary prose-blockquote:text-2xl prose-blockquote:not-italic prose-blockquote:text-dark prose-blockquote:dark:border-darkmode-primary prose-blockquote:dark:bg-darkmode-theme-light prose-blockquote:dark:text-darkmode-light;
-  @apply prose-pre:rounded-lg prose-pre:bg-theme-light prose-pre:dark:bg-darkmode-theme-light;
+  @apply prose-pre:rounded-lg prose-pre:text-dark prose-pre:bg-theme-light prose-pre:dark:bg-darkmode-theme-light;
   @apply prose-code:px-1 prose-code:dark:text-darkmode-light;
   @apply prose-strong:text-dark prose-strong:dark:text-darkmode-text;
   @apply prose-a:text-text prose-a:underline hover:prose-a:text-primary prose-a:dark:text-darkmode-text hover:prose-a:dark:text-darkmode-primary;


### PR DESCRIPTION
Fixes #6 

This change switches code blocks from looking like this:

![image](https://github.com/user-attachments/assets/9fd553a8-6e52-4666-a8c1-d29a8d915f78)

To looking like this:

![image](https://github.com/user-attachments/assets/4022b597-40cf-463b-acbb-2de83b93b4d6)

Alternatively, this line:

```scss
@apply prose-pre:rounded-lg prose-pre:bg-theme-dark prose-pre:dark:bg-darkmode-theme-light;
```

Makes the code blocks look like this:

![image](https://github.com/user-attachments/assets/007f4623-a149-47ae-b3b3-b9584b0b670a)

I don't mind which style we choose; both are better than what we currently have.
